### PR TITLE
Fix resource paths and remove SlideTransition from KV

### DIFF
--- a/game/td/app.py
+++ b/game/td/app.py
@@ -16,8 +16,8 @@ class RandomTDApp(App):
             Window.size = (1280, 720)
 
         # Load KV files
-        Builder.load_file(resource_path("td", "ui", "menu.kv"))
-        Builder.load_file(resource_path("td", "ui", "game.kv"))
+        Builder.load_file(resource_path("ui", "menu.kv"))
+        Builder.load_file(resource_path("ui", "game.kv"))
 
         from td.screens.menu import MenuScreen   # noqa
         from td.screens.game import GameScreen   # noqa

--- a/game/td/screens/game.py
+++ b/game/td/screens/game.py
@@ -16,17 +16,17 @@ class GameWidget(Widget):
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
-        self.bg_tex = CoreImage(resource_path("td", "assets", "textures", "background.png")).texture
-        self.enemy_tex = CoreImage(resource_path("td", "assets", "textures", "enemy.png")).texture
-        self.tower_tex = CoreImage(resource_path("td", "assets", "textures", "tower.png")).texture
-        self._music = SoundLoader.load(resource_path("td", "assets", "music", "loop.wav"))
+        self.bg_tex = CoreImage(resource_path("assets", "textures", "background.png")).texture
+        self.enemy_tex = CoreImage(resource_path("assets", "textures", "enemy.png")).texture
+        self.tower_tex = CoreImage(resource_path("assets", "textures", "tower.png")).texture
+        self._music = SoundLoader.load(resource_path("assets", "music", "loop.wav"))
         if self._music:
             self._music.loop = True
             self._music.volume = 0.2
             self._music.play()
 
-        self.sfx_shoot = SoundLoader.load(resource_path("td", "assets", "sfx", "shoot.wav"))
-        self.sfx_death = SoundLoader.load(resource_path("td", "assets", "sfx", "death.wav"))
+        self.sfx_shoot = SoundLoader.load(resource_path("assets", "sfx", "shoot.wav"))
+        self.sfx_death = SoundLoader.load(resource_path("assets", "sfx", "death.wav"))
 
     def on_size(self, *args):
         if self.world:

--- a/game/td/ui/menu.kv
+++ b/game/td/ui/menu.kv
@@ -1,7 +1,6 @@
 #:kivy 2.3.0
 
 <RootScreens>:
-    transition: SlideTransition()
 
 <MenuScreen>:
     BoxLayout:


### PR DESCRIPTION
## Summary
- load Kivy KV files and assets using correct resource paths
- remove undefined `SlideTransition` reference from `menu.kv`

## Testing
- `python -m compileall game`
- `python game/main.py` *(fails: libGL.so.1 missing)*

------
https://chatgpt.com/codex/tasks/task_e_68ab296484a08329a425d5a212c75d97