### PR TITLE
Add Unity project skeleton and manager class templates

### DIFF
--- a/unity/Assets/Scripts/Gameplay/Enemies/EnemyBehaviour.cs
+++ b/unity/Assets/Scripts/Gameplay/Enemies/EnemyBehaviour.cs
@@ -1,0 +1,58 @@
+using System;
+using UnityEngine;
+using TD.Managers;
+
+namespace TD.Gameplay.Enemies
+{
+    /// <summary>
+    /// Base behaviour for enemy navigation and combat interactions.
+    /// </summary>
+    public abstract class EnemyBehaviour : MonoBehaviour
+    {
+        public event Action<EnemyBehaviour> EnemyKilled;
+        public event Action<EnemyBehaviour> EnemyReachedGoal;
+        public event Action<int> HealthChanged;
+
+        [SerializeField] private string enemyId;
+        [SerializeField] private int maxHealth;
+        [SerializeField] private float moveSpeed;
+
+        protected int CurrentHealth { get; private set; }
+        protected EnemyDefinition Definition { get; private set; }
+        protected WaveManager WaveManager { get; private set; }
+
+        public string EnemyId => enemyId;
+        public int MaxHealth => maxHealth;
+        public float MoveSpeed => moveSpeed;
+
+        protected virtual void Awake()
+        {
+            // TODO: Cache components and prepare navigation/pathing.
+        }
+
+        public virtual void Initialize(EnemyDefinition definition, WaveManager waveManager)
+        {
+            // TODO: Apply definition data and prepare runtime state.
+        }
+
+        public virtual void Tick(float deltaTime)
+        {
+            // TODO: Perform movement along the path and handle interactions.
+        }
+
+        public virtual void ApplyDamage(int amount)
+        {
+            // TODO: Reduce health, broadcast changes, and handle death.
+        }
+
+        protected virtual void OnKilled()
+        {
+            // TODO: Trigger kill events and cleanup logic.
+        }
+
+        protected virtual void OnGoalReached()
+        {
+            // TODO: Notify managers about player damage and cleanup.
+        }
+    }
+}

--- a/unity/Assets/Scripts/Gameplay/Towers/TowerBehaviour.cs
+++ b/unity/Assets/Scripts/Gameplay/Towers/TowerBehaviour.cs
@@ -1,0 +1,66 @@
+using System;
+using UnityEngine;
+using TD.Managers;
+using TD.Gameplay.Enemies;
+
+namespace TD.Gameplay.Towers
+{
+    /// <summary>
+    /// Base behaviour for tower logic decoupled from presentation.
+    /// </summary>
+    public abstract class TowerBehaviour : MonoBehaviour
+    {
+        public event Action<TowerBehaviour> TargetAcquired;
+        public event Action<TowerBehaviour> TargetLost;
+        public event Action<TowerBehaviour> ShotFired;
+
+        [SerializeField] private string towerId;
+        [SerializeField] private float range;
+        [SerializeField] private float fireRate;
+        [SerializeField] private int baseDamage;
+
+        protected EnemyBehaviour CurrentTarget { get; private set; }
+        protected float CooldownTimer { get; set; }
+        protected TowerDefinition Definition { get; private set; }
+
+        public string TowerId => towerId;
+        public float Range => range;
+        public float FireRate => fireRate;
+        public int BaseDamage => baseDamage;
+
+        protected virtual void Awake()
+        {
+            // TODO: Initialize references and stats.
+        }
+
+        protected virtual void Update()
+        {
+            // TODO: Handle targeting and firing cadence.
+        }
+
+        public virtual void Initialize(TowerDefinition definition, TowerManager manager)
+        {
+            // TODO: Apply definition data and register with manager if needed.
+        }
+
+        public virtual void AcquireTarget(EnemyBehaviour enemy)
+        {
+            // TODO: Set current target and notify listeners.
+        }
+
+        public virtual void ReleaseTarget()
+        {
+            // TODO: Clear target reference and notify listeners.
+        }
+
+        public virtual void Fire()
+        {
+            // TODO: Execute attack logic and damage application.
+        }
+
+        public virtual void ApplyUpgrade(TowerUpgradeDefinition upgrade)
+        {
+            // TODO: Modify stats based on upgrade data.
+        }
+    }
+}

--- a/unity/Assets/Scripts/Managers/EnemyManager.cs
+++ b/unity/Assets/Scripts/Managers/EnemyManager.cs
@@ -1,0 +1,56 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+using TD.Gameplay.Enemies;
+
+namespace TD.Managers
+{
+    /// <summary>
+    /// Controls enemy pooling, spawning, and despawning.
+    /// </summary>
+    public class EnemyManager : MonoBehaviour
+    {
+        public event Action<EnemyBehaviour> EnemySpawned;
+        public event Action<EnemyBehaviour> EnemyDespawned;
+
+        [SerializeField] private Transform enemyRoot;
+        [SerializeField] private List<EnemyDefinition> enemyDefinitions = new();
+
+        private readonly List<EnemyBehaviour> activeEnemies = new();
+
+        public IReadOnlyList<EnemyBehaviour> ActiveEnemies => activeEnemies;
+
+        public void Initialize()
+        {
+            // TODO: Prepare object pools and lookup tables for enemy prefabs.
+        }
+
+        public EnemyBehaviour SpawnEnemy(string enemyId, Vector3 spawnPosition)
+        {
+            // TODO: Spawn or fetch enemy instance and initialize behaviour.
+            return null;
+        }
+
+        public void DespawnEnemy(EnemyBehaviour enemy)
+        {
+            // TODO: Return enemy to pool and notify listeners.
+        }
+
+        public EnemyDefinition GetEnemyDefinition(string enemyId)
+        {
+            // TODO: Retrieve definition for spawn requests or UI.
+            return null;
+        }
+    }
+
+    [Serializable]
+    public class EnemyDefinition
+    {
+        [field: SerializeField] public string EnemyId { get; private set; }
+        [field: SerializeField] public GameObject Prefab { get; private set; }
+        [field: SerializeField] public int MaxHealth { get; private set; }
+        [field: SerializeField] public float MoveSpeed { get; private set; }
+        [field: SerializeField] public int Reward { get; private set; }
+        [field: SerializeField] public int DamageToPlayer { get; private set; }
+    }
+}

--- a/unity/Assets/Scripts/Managers/GameManager.cs
+++ b/unity/Assets/Scripts/Managers/GameManager.cs
@@ -1,0 +1,97 @@
+using System;
+using UnityEngine;
+using TD.Systems;
+
+namespace TD.Managers
+{
+    /// <summary>
+    /// Coordinates high-level game flow and cross-manager communication.
+    /// </summary>
+    public class GameManager : MonoBehaviour
+    {
+        public static GameManager Instance { get; private set; }
+
+        public event Action<GameState> GameStateChanged;
+        public event Action<int> PlayerLivesChanged;
+        public event Action<int> PlayerCurrencyChanged;
+
+        [SerializeField] private LevelManager levelManager;
+        [SerializeField] private WaveManager waveManager;
+        [SerializeField] private TowerManager towerManager;
+        [SerializeField] private EnemyManager enemyManager;
+        [SerializeField] private UIManager uiManager;
+        [SerializeField] private SaveManager saveManager;
+
+        public GameState CurrentState { get; private set; } = GameState.Bootstrapping;
+        public int PlayerLives { get; private set; }
+        public int PlayerCurrency { get; private set; }
+
+        private void Awake()
+        {
+            if (Instance != null && Instance != this)
+            {
+                Destroy(gameObject);
+                return;
+            }
+
+            Instance = this;
+            DontDestroyOnLoad(gameObject);
+        }
+
+        private void Start()
+        {
+            // TODO: Initialize managers and load persistent data.
+        }
+
+        public void InitializeGame()
+        {
+            // TODO: Set up initial state, load level data, and prepare systems.
+        }
+
+        public void StartGame()
+        {
+            // TODO: Begin gameplay by starting level and waves.
+        }
+
+        public void PauseGame()
+        {
+            // TODO: Pause gameplay and notify interested systems.
+        }
+
+        public void ResumeGame()
+        {
+            // TODO: Resume gameplay from a paused state.
+        }
+
+        public void EndGame(bool victory)
+        {
+            // TODO: Handle game conclusion logic.
+        }
+
+        public void AddCurrency(int amount)
+        {
+            // TODO: Update player currency and trigger events/UI updates.
+        }
+
+        public void RemoveLife(int amount)
+        {
+            // TODO: Decrement player lives and check for defeat.
+        }
+
+        public void ChangeState(GameState newState)
+        {
+            // TODO: Transition between game states and notify listeners.
+        }
+    }
+
+    public enum GameState
+    {
+        Bootstrapping,
+        MainMenu,
+        PreparingLevel,
+        Playing,
+        Paused,
+        Victory,
+        Defeat
+    }
+}

--- a/unity/Assets/Scripts/Managers/LevelManager.cs
+++ b/unity/Assets/Scripts/Managers/LevelManager.cs
@@ -1,0 +1,72 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace TD.Managers
+{
+    /// <summary>
+    /// Handles level loading, progression, and map configuration.
+    /// </summary>
+    public class LevelManager : MonoBehaviour
+    {
+        public event Action<int> LevelLoaded;
+        public event Action<int> LevelCompleted;
+        public event Action<int> LevelFailed;
+
+        [SerializeField] private List<LevelDefinition> availableLevels = new();
+
+        public int CurrentLevelIndex { get; private set; } = -1;
+        public LevelDefinition CurrentLevel { get; private set; }
+
+        public void Initialize()
+        {
+            // TODO: Load level metadata from resources or persistence.
+        }
+
+        public void LoadLevel(int levelIndex)
+        {
+            // TODO: Load scene/level data and configure environment.
+        }
+
+        public void RestartLevel()
+        {
+            // TODO: Reset current level state and reinitialize systems.
+        }
+
+        public void CompleteLevel()
+        {
+            // TODO: Handle victory logic and trigger events.
+        }
+
+        public void FailLevel()
+        {
+            // TODO: Handle defeat logic and trigger events.
+        }
+    }
+
+    [Serializable]
+    public class LevelDefinition
+    {
+        [field: SerializeField] public string LevelName { get; private set; }
+        [field: SerializeField] public string SceneName { get; private set; }
+        [field: SerializeField] public int StartingCurrency { get; private set; }
+        [field: SerializeField] public int StartingLives { get; private set; }
+        [field: SerializeField] public List<WaveDefinition> Waves { get; private set; }
+    }
+
+    [Serializable]
+    public class WaveDefinition
+    {
+        [field: SerializeField] public string WaveId { get; private set; }
+        [field: SerializeField] public float DelayBeforeStart { get; private set; }
+        [field: SerializeField] public List<EnemySpawnDefinition> Enemies { get; private set; }
+    }
+
+    [Serializable]
+    public class EnemySpawnDefinition
+    {
+        [field: SerializeField] public string EnemyId { get; private set; }
+        [field: SerializeField] public int Count { get; private set; }
+        [field: SerializeField] public float SpawnInterval { get; private set; }
+    }
+}

--- a/unity/Assets/Scripts/Managers/TowerManager.cs
+++ b/unity/Assets/Scripts/Managers/TowerManager.cs
@@ -1,0 +1,76 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+using TD.Gameplay.Towers;
+
+namespace TD.Managers
+{
+    /// <summary>
+    /// Coordinates placement, upgrades, and lifecycle of all towers.
+    /// </summary>
+    public class TowerManager : MonoBehaviour
+    {
+        public event Action<TowerBehaviour> TowerPlaced;
+        public event Action<TowerBehaviour> TowerUpgraded;
+        public event Action<TowerBehaviour> TowerRemoved;
+
+        [SerializeField] private Transform towerRoot;
+        [SerializeField] private List<TowerDefinition> towerDefinitions = new();
+
+        private readonly List<TowerBehaviour> activeTowers = new();
+
+        public IReadOnlyList<TowerBehaviour> ActiveTowers => activeTowers;
+
+        public void Initialize()
+        {
+            // TODO: Load tower definitions and prepare pooling if necessary.
+        }
+
+        public bool CanPlaceTower(string towerId, Vector3 position)
+        {
+            // TODO: Validate placement constraints (currency, path blocking, etc.).
+            return false;
+        }
+
+        public TowerBehaviour PlaceTower(string towerId, Vector3 position)
+        {
+            // TODO: Instantiate tower prefab, initialize behaviour, and track it.
+            return null;
+        }
+
+        public void UpgradeTower(TowerBehaviour tower)
+        {
+            // TODO: Apply upgrade data and update stats/visuals.
+        }
+
+        public void RemoveTower(TowerBehaviour tower)
+        {
+            // TODO: Remove tower from play and recycle resources.
+        }
+
+        public TowerDefinition GetTowerDefinition(string towerId)
+        {
+            // TODO: Retrieve definition for UI or validation purposes.
+            return null;
+        }
+    }
+
+    [Serializable]
+    public class TowerDefinition
+    {
+        [field: SerializeField] public string TowerId { get; private set; }
+        [field: SerializeField] public GameObject Prefab { get; private set; }
+        [field: SerializeField] public int BuildCost { get; private set; }
+        [field: SerializeField] public List<TowerUpgradeDefinition> Upgrades { get; private set; }
+    }
+
+    [Serializable]
+    public class TowerUpgradeDefinition
+    {
+        [field: SerializeField] public string UpgradeId { get; private set; }
+        [field: SerializeField] public int UpgradeCost { get; private set; }
+        [field: SerializeField] public float DamageModifier { get; private set; }
+        [field: SerializeField] public float RangeModifier { get; private set; }
+        [field: SerializeField] public float FireRateModifier { get; private set; }
+    }
+}

--- a/unity/Assets/Scripts/Managers/UIManager.cs
+++ b/unity/Assets/Scripts/Managers/UIManager.cs
@@ -1,0 +1,57 @@
+using System;
+using UnityEngine;
+
+namespace TD.Managers
+{
+    /// <summary>
+    /// Handles UI screen transitions, HUD updates, and input prompts.
+    /// </summary>
+    public class UIManager : MonoBehaviour
+    {
+        public event Action<string> ScreenShown;
+        public event Action<string> ScreenHidden;
+
+        [SerializeField] private Canvas mainCanvas;
+        [SerializeField] private RectTransform hudRoot;
+        [SerializeField] private RectTransform menuRoot;
+
+        public Canvas MainCanvas => mainCanvas;
+        public RectTransform HudRoot => hudRoot;
+        public RectTransform MenuRoot => menuRoot;
+
+        public void Initialize()
+        {
+            // TODO: Cache UI references and subscribe to manager events.
+        }
+
+        public void ShowScreen(string screenId)
+        {
+            // TODO: Activate the requested screen and deactivate others.
+        }
+
+        public void HideScreen(string screenId)
+        {
+            // TODO: Hide the specified screen.
+        }
+
+        public void UpdateCurrencyDisplay(int amount)
+        {
+            // TODO: Update HUD currency text.
+        }
+
+        public void UpdateLivesDisplay(int lives)
+        {
+            // TODO: Update HUD life indicator.
+        }
+
+        public void ShowWaveIncoming(int waveIndex)
+        {
+            // TODO: Display wave notification to the player.
+        }
+
+        public void ShowResult(bool victory)
+        {
+            // TODO: Display victory/defeat panels.
+        }
+    }
+}

--- a/unity/Assets/Scripts/Managers/WaveManager.cs
+++ b/unity/Assets/Scripts/Managers/WaveManager.cs
@@ -1,0 +1,57 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace TD.Managers
+{
+    /// <summary>
+    /// Manages spawning waves of enemies and timing.
+    /// </summary>
+    public class WaveManager : MonoBehaviour
+    {
+        public event Action<int> WaveStarted;
+        public event Action<int> WaveCompleted;
+        public event Action AllWavesCompleted;
+
+        [SerializeField] private EnemyManager enemyManager;
+        [SerializeField] private LevelManager levelManager;
+
+        private readonly Queue<WaveRuntimeData> pendingWaves = new();
+        public bool IsRunning { get; private set; }
+        public int CurrentWaveIndex { get; private set; } = -1;
+
+        public void Initialize()
+        {
+            // TODO: Prepare wave queue based on current level definition.
+        }
+
+        public void StartWaves()
+        {
+            // TODO: Begin processing waves.
+        }
+
+        public void StopWaves()
+        {
+            // TODO: Stop wave progression and clear queue.
+        }
+
+        public void StartNextWave()
+        {
+            // TODO: Dequeue next wave and schedule spawns.
+        }
+
+        public void OnEnemyEliminated(string enemyId)
+        {
+            // TODO: Track remaining enemies and close wave when complete.
+        }
+    }
+
+    public class WaveRuntimeData
+    {
+        public LevelDefinition LevelDefinition { get; init; }
+        public WaveDefinition WaveDefinition { get; init; }
+        public int WaveIndex { get; init; }
+        public float TimeRemainingUntilStart { get; set; }
+        public int ActiveEnemies { get; set; }
+    }
+}

--- a/unity/Assets/Scripts/Systems/SaveManager.cs
+++ b/unity/Assets/Scripts/Systems/SaveManager.cs
@@ -1,0 +1,48 @@
+using System;
+using UnityEngine;
+
+namespace TD.Systems
+{
+    /// <summary>
+    /// Provides persistence for player progression and settings.
+    /// </summary>
+    public class SaveManager : MonoBehaviour
+    {
+        public event Action SaveCompleted;
+        public event Action LoadCompleted;
+
+        private const string SaveSlotKey = "TD_SaveSlot";
+
+        public SaveData CurrentSave { get; private set; }
+
+        public void Initialize()
+        {
+            // TODO: Load save data from disk or cloud storage.
+        }
+
+        public void Save()
+        {
+            // TODO: Serialize CurrentSave and persist to storage.
+        }
+
+        public void Load()
+        {
+            // TODO: Deserialize save data and populate CurrentSave.
+        }
+
+        public void ResetProgress()
+        {
+            // TODO: Clear progression and create a new save state.
+        }
+    }
+
+    [Serializable]
+    public class SaveData
+    {
+        public int HighestUnlockedLevel;
+        public int PlayerExperience;
+        public int SoftCurrency;
+        public int HardCurrency;
+        public bool TutorialCompleted;
+    }
+}

--- a/unity/README.md
+++ b/unity/README.md
@@ -1,0 +1,77 @@
+# Unity Tower Defense Projektstruktur
+
+## Empfohlene Ordner im Project Browser
+```
+Assets/
+  Audio/
+    Music/
+    SFX/
+  Prefabs/
+    Towers/
+    Enemies/
+    UI/
+  Scenes/
+  Scripts/
+    Gameplay/
+      Towers/
+      Enemies/
+    Managers/
+    Systems/
+  ScriptableObjects/
+    Data/
+  UI/
+```
+
+### Weitere Vorschläge
+- **Art/** (optional) für 2D/3D Assets
+- **VFX/** für Partikel- und Shader-Ressourcen
+- **Settings/** für `InputAction`-, `AudioMixer`- oder andere Projekt-Settings
+
+## Kernskripte
+Die wichtigsten Manager-Klassen befinden sich unter `Assets/Scripts/Managers/`, System-Klassen unter `Assets/Scripts/Systems/` und Gameplay-spezifische Logik unter `Assets/Scripts/Gameplay/`.
+
+Alle Klassen sind als Skeleton implementiert und enthalten TODO-Kommentare für die spätere Ausarbeitung.
+
+## Szenen-Setup
+1. **BootScene** (`Assets/Scenes/BootScene.unity`)
+   - Enthält einen persistenten `GameManager`-Prefab mit folgenden Komponenten als Kinder oder referenzierte Objekte:
+     - `GameManager` (MonoBehaviour, hängt am Root).
+     - `LevelManager`, `WaveManager`, `TowerManager`, `EnemyManager`, `UIManager`, `SaveManager` (jeweils Komponenten auf eigenen GameObjects oder als Unterobjekte des GameManagers).
+   - Setze `GameManager` auf `DontDestroyOnLoad`, damit er zwischen Szenen erhalten bleibt.
+   - Optional: Lade nach Initialisierung automatisch die Hauptmenü-Szene.
+
+2. **MainMenu** (`Assets/Scenes/MainMenu.unity`)
+   - UI-Canvas mit Menüpanel (`UIManager` referenziert diese Elemente).
+   - Buttons zum Starten eines Spiels, Öffnen der Optionen usw.
+
+3. **Level_X** (`Assets/Scenes/Level_01.unity`, etc.)
+   - Enthält die Level-Geometrie, Wegpunkte/Navigation und Platzhalter für Tower-Plätze.
+   - `EnemySpawnPoints` und `PathWaypoints` als separate GameObjects für die Gegnerbewegung.
+   - `TowerPlacementRoot` (Empty GameObject) als Elternobjekt für platzierte Türme.
+   - `EnemyRoot` (Empty GameObject) als Elternobjekt für gespawnte Gegner.
+
+## Prefab-Setup
+- **Managers/**: Erstelle Prefabs für den zentralen `GameManager` sowie die einzelnen Manager, um sie bequem in mehreren Szenen zu verwenden.
+- **Towers/**: Jeder Turm erhält ein Prefab mit `TowerBehaviour`-abgeleiteter Komponente.
+- **Enemies/**: Jeder Gegnertyp erhält ein Prefab mit `EnemyBehaviour`-abgeleiteter Komponente.
+- **UI/**: HUD-, Menü- und Popup-Prefabs, die vom `UIManager` angesteuert werden.
+
+## Script-Anbindung
+- `GameManager`: Hängt am persistenten GameObject "GameManager" in der BootScene. Referenzen zu allen anderen Managern werden im Inspector gesetzt.
+- `LevelManager`: Eigenes GameObject "LevelManager" oder Child des GameManagers. Hat Zugriff auf Level-Definitionen (ScriptableObjects in `Assets/ScriptableObjects/Data`).
+- `WaveManager`: Child "WaveManager" mit Referenz auf `EnemyManager` und `LevelManager`.
+- `TowerManager`: Child "TowerManager" mit Referenzen auf `TowerPlacementRoot` und Tower-Definitionen.
+- `EnemyManager`: Child "EnemyManager" mit Referenz auf `EnemyRoot` und Enemyprefabs.
+- `UIManager`: Liegt auf einem UI GameObject im Canvas, referenziert HUD- und Menü-Container.
+- `SaveManager`: Child "SaveManager" (oder `ScriptableObject`-basierter Service). Wird vom `GameManager` verwendet.
+
+## Weitere Empfehlungen
+- Lagere Balancing-Daten (Tower-, Enemy-, Level-Definitionen) in ScriptableObjects im Ordner `Assets/ScriptableObjects/Data/` aus.
+- Verwende `Addressables` oder `AssetBundles`, wenn du später LiveOps/Content-Updates planst.
+- Für Mobile-spezifische Optimierungen: Ziel ist es, Manager-Logik vom Rendering zu trennen, damit UI/Gameplay unabhängig skaliert werden können (z. B. durch `Update` vs. `FixedUpdate`, Job-System, oder eigene Ticker).
+
+## Nächste Schritte
+1. Implementiere die TODOs in den Skeleton-Klassen.
+2. Erstelle konkrete abgeleitete Klassen (`ProjectileTower`, `SlowEnemy`, etc.) in den entsprechenden Gameplay-Ordnern.
+3. Füge ScriptableObjects zur Konfiguration hinzu.
+4. Erweitere den `SaveManager` um Cloud-Sync oder mobile-spezifische Speicherroutinen.


### PR DESCRIPTION
## Summary
- add Unity-oriented project folder structure guidance and scene setup documentation
- implement skeleton C# scripts for core managers, systems, and gameplay behaviours for a mobile-ready tower defense
- define serializable data containers for levels, waves, towers, and enemies with TODO placeholders for implementation

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69145cfe307c832986b83bb38e3e1c20)