### PR TITLE
Add grid, path, and tower placement systems

### DIFF
--- a/unity/Assets/Scripts/Gameplay/Enemies/EnemyBehaviour.cs
+++ b/unity/Assets/Scripts/Gameplay/Enemies/EnemyBehaviour.cs
@@ -16,6 +16,8 @@ namespace TD.Gameplay.Enemies
         [SerializeField] private string enemyId;
         [SerializeField] private int maxHealth;
         [SerializeField] private float moveSpeed;
+        [SerializeField] private WaypointPath waypointPath;
+        [SerializeField] private float waypointArrivalDistance = 0.05f;
 
         protected int CurrentHealth { get; private set; }
         protected EnemyDefinition Definition { get; private set; }
@@ -27,32 +29,110 @@ namespace TD.Gameplay.Enemies
 
         protected virtual void Awake()
         {
-            // TODO: Cache components and prepare navigation/pathing.
+            waypointPath ??= GetComponentInParent<WaypointPath>();
+            CurrentHealth = maxHealth;
+            currentWaypointIndex = 0;
+            hasReachedGoal = false;
         }
 
         public virtual void Initialize(EnemyDefinition definition, WaveManager waveManager)
         {
-            // TODO: Apply definition data and prepare runtime state.
+            Definition = definition;
+            WaveManager = waveManager;
+
+            if (definition != null)
+            {
+                enemyId = definition.EnemyId;
+                maxHealth = definition.MaxHealth;
+                moveSpeed = definition.MoveSpeed;
+            }
+
+            CurrentHealth = maxHealth;
+            HealthChanged?.Invoke(CurrentHealth);
+            ResetPath();
         }
 
         public virtual void Tick(float deltaTime)
         {
-            // TODO: Perform movement along the path and handle interactions.
+            if (hasReachedGoal || waypointPath == null)
+            {
+                return;
+            }
+
+            if (waypointPath.Waypoints.Count == 0)
+            {
+                return;
+            }
+
+            var targetPosition = waypointPath.GetWaypointPosition(currentWaypointIndex);
+            var toTarget = targetPosition - transform.position;
+
+            if (toTarget.sqrMagnitude <= waypointArrivalDistance * waypointArrivalDistance)
+            {
+                if (!waypointPath.Loop && currentWaypointIndex >= waypointPath.Waypoints.Count - 1)
+                {
+                    hasReachedGoal = true;
+                    OnGoalReached();
+                    return;
+                }
+
+                currentWaypointIndex = waypointPath.GetNextIndex(currentWaypointIndex);
+                targetPosition = waypointPath.GetWaypointPosition(currentWaypointIndex);
+                toTarget = targetPosition - transform.position;
+            }
+
+            if (toTarget.sqrMagnitude > 0.0001f)
+            {
+                var movement = toTarget.normalized * moveSpeed * deltaTime;
+                if (movement.sqrMagnitude > toTarget.sqrMagnitude)
+                {
+                    movement = toTarget;
+                }
+
+                transform.position += movement;
+            }
         }
 
         public virtual void ApplyDamage(int amount)
         {
-            // TODO: Reduce health, broadcast changes, and handle death.
+            if (amount <= 0 || CurrentHealth <= 0)
+            {
+                return;
+            }
+
+            CurrentHealth = Mathf.Max(0, CurrentHealth - amount);
+            HealthChanged?.Invoke(CurrentHealth);
+
+            if (CurrentHealth <= 0)
+            {
+                OnKilled();
+            }
         }
 
         protected virtual void OnKilled()
         {
-            // TODO: Trigger kill events and cleanup logic.
+            EnemyKilled?.Invoke(this);
+            Destroy(gameObject);
         }
 
         protected virtual void OnGoalReached()
         {
-            // TODO: Notify managers about player damage and cleanup.
+            EnemyReachedGoal?.Invoke(this);
+            Destroy(gameObject);
         }
+
+        protected virtual void Update()
+        {
+            Tick(Time.deltaTime);
+        }
+
+        private void ResetPath()
+        {
+            hasReachedGoal = false;
+            currentWaypointIndex = 0;
+        }
+
+        private int currentWaypointIndex;
+        private bool hasReachedGoal;
     }
 }

--- a/unity/Assets/Scripts/Gameplay/Enemies/WaypointPath.cs
+++ b/unity/Assets/Scripts/Gameplay/Enemies/WaypointPath.cs
@@ -1,0 +1,82 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace TD.Gameplay.Enemies
+{
+    /// <summary>
+    /// Stores an ordered list of waypoints that enemies will follow.
+    /// Children of this transform are automatically treated as waypoints when the list is empty.
+    /// </summary>
+    public class WaypointPath : MonoBehaviour
+    {
+        [SerializeField] private List<Transform> waypoints = new();
+        [SerializeField] private bool loop;
+
+        public IReadOnlyList<Transform> Waypoints => waypoints;
+        public bool Loop => loop;
+
+        private void Awake()
+        {
+            if (waypoints.Count == 0)
+            {
+                waypoints.AddRange(GetChildWaypoints());
+            }
+        }
+
+        public Vector3 GetWaypointPosition(int index)
+        {
+            if (waypoints.Count == 0)
+            {
+                return transform.position;
+            }
+
+            index = Mathf.Clamp(index, 0, waypoints.Count - 1);
+            return waypoints[index].position;
+        }
+
+        public int GetNextIndex(int currentIndex)
+        {
+            if (waypoints.Count == 0)
+            {
+                return 0;
+            }
+
+            var nextIndex = currentIndex + 1;
+            if (nextIndex >= waypoints.Count)
+            {
+                nextIndex = loop ? 0 : waypoints.Count - 1;
+            }
+
+            return nextIndex;
+        }
+
+        private IEnumerable<Transform> GetChildWaypoints()
+        {
+            foreach (Transform child in transform)
+            {
+                yield return child;
+            }
+        }
+
+#if UNITY_EDITOR
+        private void OnDrawGizmos()
+        {
+            if (waypoints.Count == 0)
+            {
+                return;
+            }
+
+            Gizmos.color = Color.yellow;
+            for (var i = 0; i < waypoints.Count - 1; i++)
+            {
+                Gizmos.DrawLine(waypoints[i].position, waypoints[i + 1].position);
+            }
+
+            if (loop && waypoints.Count > 1)
+            {
+                Gizmos.DrawLine(waypoints[waypoints.Count - 1].position, waypoints[0].position);
+            }
+        }
+#endif
+    }
+}

--- a/unity/Assets/Scripts/Gameplay/Towers/TowerBehaviour.cs
+++ b/unity/Assets/Scripts/Gameplay/Towers/TowerBehaviour.cs
@@ -30,37 +30,82 @@ namespace TD.Gameplay.Towers
 
         protected virtual void Awake()
         {
-            // TODO: Initialize references and stats.
+            CooldownTimer = 0f;
         }
 
         protected virtual void Update()
         {
-            // TODO: Handle targeting and firing cadence.
+            if (CurrentTarget == null)
+            {
+                return;
+            }
+
+            if (!CurrentTarget || Vector3.Distance(transform.position, CurrentTarget.transform.position) > range)
+            {
+                ReleaseTarget();
+                return;
+            }
+
+            if (CooldownTimer > 0f)
+            {
+                CooldownTimer -= Time.deltaTime;
+            }
+
+            if (CooldownTimer <= 0f)
+            {
+                Fire();
+            }
         }
 
         public virtual void Initialize(TowerDefinition definition, TowerManager manager)
         {
-            // TODO: Apply definition data and register with manager if needed.
+            Definition = definition;
         }
 
         public virtual void AcquireTarget(EnemyBehaviour enemy)
         {
-            // TODO: Set current target and notify listeners.
+            if (enemy == null)
+            {
+                return;
+            }
+
+            CurrentTarget = enemy;
+            TargetAcquired?.Invoke(this);
         }
 
         public virtual void ReleaseTarget()
         {
-            // TODO: Clear target reference and notify listeners.
+            if (CurrentTarget == null)
+            {
+                return;
+            }
+
+            CurrentTarget = null;
+            TargetLost?.Invoke(this);
         }
 
         public virtual void Fire()
         {
-            // TODO: Execute attack logic and damage application.
+            if (CurrentTarget == null)
+            {
+                return;
+            }
+
+            CurrentTarget.ApplyDamage(baseDamage);
+            ShotFired?.Invoke(this);
+            CooldownTimer = FireRate > 0f ? 1f / FireRate : 0f;
         }
 
         public virtual void ApplyUpgrade(TowerUpgradeDefinition upgrade)
         {
-            // TODO: Modify stats based on upgrade data.
+            if (upgrade == null)
+            {
+                return;
+            }
+
+            baseDamage = Mathf.RoundToInt(baseDamage * upgrade.DamageModifier);
+            range *= upgrade.RangeModifier;
+            fireRate *= upgrade.FireRateModifier;
         }
     }
 }

--- a/unity/Assets/Scripts/Gameplay/Towers/TowerPlacementController.cs
+++ b/unity/Assets/Scripts/Gameplay/Towers/TowerPlacementController.cs
@@ -1,0 +1,181 @@
+using UnityEngine;
+using TD.Managers;
+using TD.Systems.Grid;
+
+namespace TD.Gameplay.Towers
+{
+    /// <summary>
+    /// Handles user input to place towers on valid grid tiles using touch or mouse input.
+    /// </summary>
+    public class TowerPlacementController : MonoBehaviour
+    {
+        [SerializeField] private TowerManager towerManager;
+        [SerializeField] private GridManager gridManager;
+        [SerializeField] private Camera worldCamera;
+        [SerializeField] private TowerPlacementPreview placementPreviewPrefab;
+        [SerializeField] private Transform previewParent;
+
+        private TowerPlacementPreview previewInstance;
+        private TowerDefinition selectedDefinition;
+        private bool hasValidPosition;
+
+        private void Awake()
+        {
+            EnsurePreviewInstance();
+            HidePreview();
+        }
+
+        private void Update()
+        {
+            if (selectedDefinition == null)
+            {
+                HidePreview();
+                return;
+            }
+
+            if (TryGetPointerWorldPosition(out var worldPosition, out var pointerReleased))
+            {
+                if (gridManager.TryGetGridPosition(worldPosition, out var gridPosition))
+                {
+                    var snapped = gridManager.GetWorldPosition(gridPosition);
+                    hasValidPosition = towerManager.CanPlaceTower(selectedDefinition.TowerId, gridPosition);
+
+                    previewInstance.SetVisibility(true);
+                    previewInstance.SetPosition(snapped);
+                    previewInstance.SetPlacementValidity(hasValidPosition);
+
+                    if (pointerReleased && hasValidPosition)
+                    {
+                        if (towerManager.TryPlaceTower(selectedDefinition.TowerId, gridPosition, out _))
+                        {
+                            // Keep selection active to allow rapid placement until the player cancels.
+                            hasValidPosition = false;
+                        }
+                    }
+                }
+                else
+                {
+                    ShowInvalidPreview(worldPosition);
+                }
+            }
+            else
+            {
+                previewInstance.SetVisibility(false);
+            }
+        }
+
+        /// <summary>
+        /// Called by UI buttons to select the tower that should be placed next.
+        /// </summary>
+        public void SelectTower(string towerId)
+        {
+            selectedDefinition = towerManager.GetTowerDefinition(towerId);
+            if (selectedDefinition == null)
+            {
+                Debug.LogWarning($"Cannot select tower '{towerId}' – definition not found.");
+                HidePreview();
+                return;
+            }
+
+            EnsurePreviewInstance();
+            previewInstance.SetVisibility(true);
+            previewInstance.SetPlacementValidity(false);
+        }
+
+        public void CancelSelection()
+        {
+            selectedDefinition = null;
+            HidePreview();
+        }
+
+        private void ShowInvalidPreview(Vector3 worldPosition)
+        {
+            EnsurePreviewInstance();
+            previewInstance.SetVisibility(true);
+            previewInstance.SetPlacementValidity(false);
+            previewInstance.SetPosition(worldPosition);
+            hasValidPosition = false;
+        }
+
+        private void HidePreview()
+        {
+            if (previewInstance != null)
+            {
+                previewInstance.SetVisibility(false);
+            }
+
+            hasValidPosition = false;
+        }
+
+        private void EnsurePreviewInstance()
+        {
+            if (previewInstance != null || placementPreviewPrefab == null)
+            {
+                return;
+            }
+
+            var parent = previewParent != null ? previewParent : transform;
+            previewInstance = Instantiate(placementPreviewPrefab, parent);
+            previewInstance.SetVisibility(false);
+        }
+
+        private bool TryGetPointerWorldPosition(out Vector3 worldPosition, out bool pointerReleased)
+        {
+            pointerReleased = false;
+
+            if (Input.touchCount > 0)
+            {
+                var touch = Input.GetTouch(0);
+                if (touch.phase == TouchPhase.Canceled)
+                {
+                    worldPosition = default;
+                    return false;
+                }
+
+                pointerReleased = touch.phase == TouchPhase.Ended;
+                worldPosition = ScreenToWorld(touch.position);
+                return true;
+            }
+
+            if (Input.GetMouseButtonDown(0) || Input.GetMouseButton(0) || Input.GetMouseButtonUp(0))
+            {
+                pointerReleased = Input.GetMouseButtonUp(0);
+                worldPosition = ScreenToWorld(Input.mousePosition);
+                return true;
+            }
+
+            worldPosition = default;
+            return false;
+        }
+
+        private Vector3 ScreenToWorld(Vector2 screenPosition)
+        {
+            if (worldCamera == null)
+            {
+                worldCamera = Camera.main;
+            }
+
+            if (worldCamera == null)
+            {
+                Debug.LogError("TowerPlacementController requires a Camera reference.");
+                return Vector3.zero;
+            }
+
+            var ray = worldCamera.ScreenPointToRay(screenPosition);
+            var plane = new Plane(Vector3.forward, Vector3.zero);
+
+            if (plane.Raycast(ray, out var distance))
+            {
+                var worldPoint = ray.GetPoint(distance);
+                worldPoint.z = 0f;
+                return worldPoint;
+            }
+
+            // Fallback for orthographic cameras looking along the forward axis.
+            var fallback = worldCamera.ScreenToWorldPoint(new Vector3(screenPosition.x, screenPosition.y,
+                Mathf.Abs(worldCamera.transform.position.z)));
+            fallback.z = 0f;
+            return fallback;
+        }
+    }
+}

--- a/unity/Assets/Scripts/Gameplay/Towers/TowerPlacementPreview.cs
+++ b/unity/Assets/Scripts/Gameplay/Towers/TowerPlacementPreview.cs
@@ -1,0 +1,71 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace TD.Gameplay.Towers
+{
+    /// <summary>
+    /// Helper component that adjusts preview visuals during placement.
+    /// </summary>
+    public class TowerPlacementPreview : MonoBehaviour
+    {
+        [SerializeField] private Color validColor = new(0f, 1f, 0f, 0.45f);
+        [SerializeField] private Color invalidColor = new(1f, 0f, 0f, 0.45f);
+
+        private readonly List<SpriteRenderer> spriteRenderers = new();
+        private readonly List<Renderer> meshRenderers = new();
+        private readonly Dictionary<Renderer, MaterialPropertyBlock> propertyBlocks = new();
+
+        private void Awake()
+        {
+            spriteRenderers.AddRange(GetComponentsInChildren<SpriteRenderer>(true));
+
+            var renderers = GetComponentsInChildren<Renderer>(true);
+            foreach (var renderer in renderers)
+            {
+                if (renderer is SpriteRenderer)
+                {
+                    continue;
+                }
+
+                meshRenderers.Add(renderer);
+                propertyBlocks[renderer] = new MaterialPropertyBlock();
+            }
+        }
+
+        public void SetVisibility(bool visible)
+        {
+            if (gameObject.activeSelf != visible)
+            {
+                gameObject.SetActive(visible);
+            }
+        }
+
+        public void SetPlacementValidity(bool isValid)
+        {
+            var targetColor = isValid ? validColor : invalidColor;
+
+            foreach (var spriteRenderer in spriteRenderers)
+            {
+                spriteRenderer.color = targetColor;
+            }
+
+            foreach (var meshRenderer in meshRenderers)
+            {
+                if (!propertyBlocks.TryGetValue(meshRenderer, out var block))
+                {
+                    block = new MaterialPropertyBlock();
+                    propertyBlocks[meshRenderer] = block;
+                }
+
+                meshRenderer.GetPropertyBlock(block);
+                block.SetColor("_Color", targetColor);
+                meshRenderer.SetPropertyBlock(block);
+            }
+        }
+
+        public void SetPosition(Vector3 worldPosition)
+        {
+            transform.position = worldPosition;
+        }
+    }
+}

--- a/unity/Assets/Scripts/Systems/Grid/GridManager.cs
+++ b/unity/Assets/Scripts/Systems/Grid/GridManager.cs
@@ -1,0 +1,172 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace TD.Systems.Grid
+{
+    /// <summary>
+    /// Central authority for translating between grid coordinates and world positions,
+    /// and for tracking tile availability/occupancy.
+    /// </summary>
+    public class GridManager : MonoBehaviour
+    {
+        [SerializeField] private int width = 10;
+        [SerializeField] private int height = 10;
+        [SerializeField] private float cellSize = 1f;
+        [SerializeField] private Vector2 originPosition = Vector2.zero;
+        [SerializeField] private bool initialiseBuildableTiles = true;
+        [SerializeField] private List<Vector2Int> blockedTiles = new();
+        [SerializeField] private Color debugBuildableColor = new(0f, 1f, 0f, 0.25f);
+        [SerializeField] private Color debugBlockedColor = new(1f, 0f, 0f, 0.25f);
+        [SerializeField] private bool drawDebugGizmos = true;
+
+        private GridTile[,] tiles;
+
+        public int Width => width;
+        public int Height => height;
+        public float CellSize => cellSize;
+
+        private void Awake()
+        {
+            InitialiseTiles();
+        }
+
+        private void InitialiseTiles()
+        {
+            tiles = new GridTile[width, height];
+            for (var x = 0; x < width; x++)
+            {
+                for (var y = 0; y < height; y++)
+                {
+                    tiles[x, y] = new GridTile
+                    {
+                        IsBuildable = initialiseBuildableTiles,
+                        IsOccupied = false
+                    };
+                }
+            }
+
+            foreach (var tile in blockedTiles)
+            {
+                if (IsInBounds(tile))
+                {
+                    tiles[tile.x, tile.y].IsBuildable = false;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Converts a grid coordinate into the centre position in world space.
+        /// </summary>
+        public Vector3 GetWorldPosition(Vector2Int gridPosition)
+        {
+            var offset = new Vector2((gridPosition.x + 0.5f) * cellSize, (gridPosition.y + 0.5f) * cellSize);
+            return new Vector3(originPosition.x + offset.x, originPosition.y + offset.y, 0f);
+        }
+
+        /// <summary>
+        /// Converts world position into grid coordinates if within bounds.
+        /// </summary>
+        public bool TryGetGridPosition(Vector3 worldPosition, out Vector2Int gridPosition)
+        {
+            var relative = new Vector2(worldPosition.x - originPosition.x, worldPosition.y - originPosition.y);
+            var x = Mathf.FloorToInt(relative.x / cellSize);
+            var y = Mathf.FloorToInt(relative.y / cellSize);
+
+            gridPosition = new Vector2Int(x, y);
+            return IsInBounds(gridPosition);
+        }
+
+        public bool IsInBounds(Vector2Int gridPosition)
+        {
+            return gridPosition.x >= 0 && gridPosition.y >= 0 && gridPosition.x < width && gridPosition.y < height;
+        }
+
+        public void SetBuildable(Vector2Int gridPosition, bool buildable)
+        {
+            if (!IsInBounds(gridPosition))
+            {
+                throw new ArgumentOutOfRangeException(nameof(gridPosition), "Grid position is outside bounds.");
+            }
+
+            tiles[gridPosition.x, gridPosition.y].IsBuildable = buildable;
+        }
+
+        public bool IsBuildable(Vector2Int gridPosition)
+        {
+            if (!IsInBounds(gridPosition))
+            {
+                return false;
+            }
+
+            return tiles[gridPosition.x, gridPosition.y].IsBuildable;
+        }
+
+        public bool IsOccupied(Vector2Int gridPosition)
+        {
+            if (!IsInBounds(gridPosition))
+            {
+                return true;
+            }
+
+            return tiles[gridPosition.x, gridPosition.y].IsOccupied;
+        }
+
+        public bool CanPlaceStructure(Vector2Int gridPosition)
+        {
+            return IsBuildable(gridPosition) && !IsOccupied(gridPosition);
+        }
+
+        public bool TryReserveTile(Vector2Int gridPosition)
+        {
+            if (!CanPlaceStructure(gridPosition))
+            {
+                return false;
+            }
+
+            tiles[gridPosition.x, gridPosition.y].IsOccupied = true;
+            return true;
+        }
+
+        public void ReleaseTile(Vector2Int gridPosition)
+        {
+            if (!IsInBounds(gridPosition))
+            {
+                return;
+            }
+
+            tiles[gridPosition.x, gridPosition.y].IsOccupied = false;
+        }
+
+        private void OnDrawGizmosSelected()
+        {
+            if (!drawDebugGizmos)
+            {
+                return;
+            }
+
+            Gizmos.matrix = Matrix4x4.identity;
+
+            for (var x = 0; x < width; x++)
+            {
+                for (var y = 0; y < height; y++)
+                {
+                    var gridPos = new Vector2Int(x, y);
+                    var worldPos = GetWorldPosition(gridPos);
+                    var halfSize = new Vector3(cellSize, cellSize, 0f) * 0.5f;
+                    Gizmos.color = IsBuildable(gridPos) ? debugBuildableColor : debugBlockedColor;
+                    Gizmos.DrawCube(worldPos, halfSize * 2f);
+                    Gizmos.color = Color.black;
+                    Gizmos.DrawWireCube(worldPos, halfSize * 2f);
+                }
+            }
+        }
+
+        [Serializable]
+        private class GridTile
+        {
+            public bool IsBuildable;
+            public bool IsOccupied;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a grid manager that converts between grid/world coordinates and tracks buildable and occupied tiles
- implement waypoint path following for enemies and update enemy behaviour health handling
- expand tower management to respect currency/grid reservations and add touch-friendly tower placement with previews

## Testing
- not run (Unity editor feature code)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6914658c90b883298cb631442f5acaf2)