### PR TITLE
Add data-driven tower combat system

### DIFF
--- a/unity/Assets/Scripts/Gameplay/Data/DamageType.cs
+++ b/unity/Assets/Scripts/Gameplay/Data/DamageType.cs
@@ -1,0 +1,9 @@
+namespace TD.Gameplay.Enemies
+{
+    public enum DamageType
+    {
+        Physical,
+        Magical,
+        True
+    }
+}

--- a/unity/Assets/Scripts/Gameplay/Data/EnemyData.cs
+++ b/unity/Assets/Scripts/Gameplay/Data/EnemyData.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace TD.Gameplay.Data
+{
+    /// <summary>
+    /// Immutable configuration for an enemy archetype.
+    /// </summary>
+    [CreateAssetMenu(menuName = "TD/Data/Enemy", fileName = "EnemyData")]
+    public class EnemyData : ScriptableObject
+    {
+        [SerializeField] private string enemyId = Guid.NewGuid().ToString();
+        [SerializeField, Min(1)] private int maxHealth = 10;
+        [SerializeField, Min(0.1f)] private float moveSpeed = 1.5f;
+        [SerializeField, Range(0f, 0.95f)] private float armor = 0f;
+        [SerializeField] private List<DamageResistance> resistances = new();
+
+        public string EnemyId => enemyId;
+        public int MaxHealth => maxHealth;
+        public float MoveSpeed => moveSpeed;
+        public float Armor => armor;
+        public IReadOnlyList<DamageResistance> Resistances => resistances;
+    }
+
+    [Serializable]
+    public struct DamageResistance
+    {
+        [SerializeField] private TD.Gameplay.Enemies.DamageType damageType;
+        [SerializeField, Range(0f, 1f)] private float reduction;
+
+        public TD.Gameplay.Enemies.DamageType DamageType => damageType;
+        public float Reduction => reduction;
+    }
+}

--- a/unity/Assets/Scripts/Gameplay/Data/TowerData.cs
+++ b/unity/Assets/Scripts/Gameplay/Data/TowerData.cs
@@ -1,0 +1,41 @@
+using System;
+using UnityEngine;
+using TD.Gameplay.Enemies;
+using TD.Gameplay.Towers;
+
+namespace TD.Gameplay.Data
+{
+    /// <summary>
+    /// Immutable data configuration for a tower.
+    /// </summary>
+    [CreateAssetMenu(menuName = "TD/Data/Tower", fileName = "TowerData")]
+    public class TowerData : ScriptableObject
+    {
+        [SerializeField] private string towerId = Guid.NewGuid().ToString();
+        [SerializeField] private float range = 5f;
+        [SerializeField, Min(0.1f)] private float fireRate = 1f;
+        [SerializeField, Min(1)] private int damage = 1;
+        [SerializeField] private DamageType damageType = DamageType.Physical;
+        [SerializeField] private TargetPriority targetPriority = TargetPriority.First;
+        [SerializeField] private ProjectileBehaviour projectilePrefab;
+        [SerializeField, Min(0.1f)] private float projectileSpeed = 10f;
+        [SerializeField, Min(1)] private int projectilePoolSize = 8;
+
+        public string TowerId => towerId;
+        public float Range => range;
+        public float FireRate => fireRate;
+        public int Damage => damage;
+        public DamageType DamageType => damageType;
+        public TargetPriority TargetPriority => targetPriority;
+        public ProjectileBehaviour ProjectilePrefab => projectilePrefab;
+        public float ProjectileSpeed => projectileSpeed;
+        public int ProjectilePoolSize => projectilePoolSize;
+    }
+
+    public enum TargetPriority
+    {
+        First,
+        Last,
+        Strongest
+    }
+}

--- a/unity/Assets/Scripts/Gameplay/Towers/ProjectileBehaviour.cs
+++ b/unity/Assets/Scripts/Gameplay/Towers/ProjectileBehaviour.cs
@@ -1,0 +1,81 @@
+using UnityEngine;
+using TD.Gameplay.Enemies;
+using TD.Systems;
+
+namespace TD.Gameplay.Towers
+{
+    /// <summary>
+    /// Handles projectile travel and applying damage on impact before returning to the pool.
+    /// </summary>
+    public class ProjectileBehaviour : MonoBehaviour
+    {
+        [SerializeField, Min(0.1f)] private float lifeTime = 3f;
+
+        private EnemyBehaviour target;
+        private int damage;
+        private float speed;
+        private DamageType damageType;
+        private ObjectPool<ProjectileBehaviour> pool;
+        private float timeRemaining;
+
+        public void Launch(EnemyBehaviour target, int damage, float speed, DamageType damageType, ObjectPool<ProjectileBehaviour> pool)
+        {
+            this.target = target;
+            this.damage = damage;
+            this.speed = speed;
+            this.damageType = damageType;
+            this.pool = pool;
+            timeRemaining = lifeTime;
+        }
+
+        private void Update()
+        {
+            if (target == null || !target.IsAlive)
+            {
+                Release();
+                return;
+            }
+
+            timeRemaining -= Time.deltaTime;
+            if (timeRemaining <= 0f)
+            {
+                Release();
+                return;
+            }
+
+            var targetPosition = target.AimPosition;
+            var toTarget = targetPosition - transform.position;
+            var distanceThisFrame = speed * Time.deltaTime;
+
+            if (toTarget.sqrMagnitude <= distanceThisFrame * distanceThisFrame)
+            {
+                Impact();
+            }
+            else
+            {
+                var direction = toTarget.normalized;
+                transform.position += direction * distanceThisFrame;
+                if (direction.sqrMagnitude > 0f)
+                {
+                    transform.forward = direction;
+                }
+            }
+        }
+
+        private void Impact()
+        {
+            if (target != null)
+            {
+                target.ReceiveDamage(damage, damageType);
+            }
+
+            Release();
+        }
+
+        private void Release()
+        {
+            target = null;
+            pool?.Release(this);
+        }
+    }
+}

--- a/unity/Assets/Scripts/Systems/Health.cs
+++ b/unity/Assets/Scripts/Systems/Health.cs
@@ -1,0 +1,75 @@
+using System;
+using UnityEngine;
+
+namespace TD.Systems
+{
+    /// <summary>
+    /// Reusable health component emitting events on state changes.
+    /// </summary>
+    public class Health : MonoBehaviour
+    {
+        public event Action<Health, int, int> HealthChanged;
+        public event Action<Health> Died;
+
+        [SerializeField, Min(1)] private int maxHealth = 1;
+
+        public int MaxHealth => maxHealth;
+        public int CurrentHealth { get; private set; }
+        public bool IsDead => CurrentHealth <= 0;
+
+        private void Awake()
+        {
+            CurrentHealth = Mathf.Clamp(CurrentHealth, 0, maxHealth);
+            if (CurrentHealth == 0)
+            {
+                CurrentHealth = maxHealth;
+            }
+        }
+
+        public void Initialize(int max)
+        {
+            maxHealth = Mathf.Max(1, max);
+            ResetHealth();
+        }
+
+        public void ResetHealth()
+        {
+            CurrentHealth = maxHealth;
+            HealthChanged?.Invoke(this, CurrentHealth, maxHealth);
+        }
+
+        public void TakeDamage(int amount)
+        {
+            if (IsDead || amount <= 0)
+            {
+                return;
+            }
+
+            var newValue = Mathf.Max(0, CurrentHealth - amount);
+            if (newValue == CurrentHealth)
+            {
+                return;
+            }
+
+            CurrentHealth = newValue;
+            HealthChanged?.Invoke(this, CurrentHealth, maxHealth);
+
+            if (CurrentHealth <= 0)
+            {
+                Died?.Invoke(this);
+            }
+        }
+
+        public void Kill()
+        {
+            if (IsDead)
+            {
+                return;
+            }
+
+            CurrentHealth = 0;
+            HealthChanged?.Invoke(this, CurrentHealth, maxHealth);
+            Died?.Invoke(this);
+        }
+    }
+}

--- a/unity/Assets/Scripts/Systems/ObjectPool.cs
+++ b/unity/Assets/Scripts/Systems/ObjectPool.cs
@@ -1,0 +1,69 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace TD.Systems
+{
+    /// <summary>
+    /// Lightweight generic object pool for Components.
+    /// </summary>
+    /// <typeparam name="T">Component type stored in the pool.</typeparam>
+    public class ObjectPool<T> where T : Component
+    {
+        private readonly Stack<T> pool = new();
+        private readonly T prefab;
+        private readonly Transform parent;
+
+        public ObjectPool(T prefab, int initialSize, Transform parent = null)
+        {
+            this.prefab = prefab;
+            this.parent = parent;
+
+            if (prefab == null)
+            {
+                Debug.LogError("ObjectPool created without a prefab.");
+                return;
+            }
+
+            for (var i = 0; i < initialSize; i++)
+            {
+                var instance = CreateInstance();
+                ReturnToPool(instance);
+            }
+        }
+
+        public T Get()
+        {
+            if (pool.Count == 0)
+            {
+                return CreateInstance(true);
+            }
+
+            var instance = pool.Pop();
+            instance.gameObject.SetActive(true);
+            return instance;
+        }
+
+        public void Release(T instance)
+        {
+            if (instance == null)
+            {
+                return;
+            }
+
+            ReturnToPool(instance);
+        }
+
+        private T CreateInstance(bool activate = false)
+        {
+            var instance = Object.Instantiate(prefab, parent);
+            instance.gameObject.SetActive(activate);
+            return instance;
+        }
+
+        private void ReturnToPool(T instance)
+        {
+            instance.gameObject.SetActive(false);
+            pool.Push(instance);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add ScriptableObjects for towers and enemies along with shared damage types
- implement tower, enemy, and projectile behaviours including targeting logic and projectile pooling
- add reusable health and generic object pool utilities used by combat systems

## Testing
- not run (Unity project)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6914696eb4f083299cc845eb237339dc)