### PR TITLE
Implement data-driven level and wave system

### DIFF
--- a/unity/Assets/Scripts/Data/LevelData.cs
+++ b/unity/Assets/Scripts/Data/LevelData.cs
@@ -1,0 +1,26 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace TD.Data
+{
+    /// <summary>
+    /// ScriptableObject that stores level configuration such as start resources and wave layout.
+    /// </summary>
+    [CreateAssetMenu(menuName = "TD/Levels/Level Data", fileName = "LevelData")]
+    public class LevelData : ScriptableObject
+    {
+        [SerializeField] private string levelId;
+        [SerializeField] private string displayName;
+        [SerializeField] private string sceneName;
+        [SerializeField] private int startingCurrency = 100;
+        [SerializeField] private int startingLives = 20;
+        [SerializeField] private List<WaveData> waves = new();
+
+        public string LevelId => levelId;
+        public string DisplayName => displayName;
+        public string SceneName => sceneName;
+        public int StartingCurrency => startingCurrency;
+        public int StartingLives => startingLives;
+        public IReadOnlyList<WaveData> Waves => waves;
+    }
+}

--- a/unity/Assets/Scripts/Data/WaveData.cs
+++ b/unity/Assets/Scripts/Data/WaveData.cs
@@ -1,0 +1,33 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace TD.Data
+{
+    /// <summary>
+    /// ScriptableObject describing a single enemy wave.
+    /// </summary>
+    [CreateAssetMenu(menuName = "TD/Levels/Wave Data", fileName = "WaveData")]
+    public class WaveData : ScriptableObject
+    {
+        [SerializeField] private string waveId;
+        [SerializeField] private float startDelay;
+        [SerializeField] private List<SpawnGroup> spawnGroups = new();
+
+        public string WaveId => waveId;
+        public float StartDelay => Mathf.Max(0f, startDelay);
+        public IReadOnlyList<SpawnGroup> SpawnGroups => spawnGroups;
+
+        [Serializable]
+        public class SpawnGroup
+        {
+            [SerializeField] private string enemyId;
+            [SerializeField] private int count = 1;
+            [SerializeField] private float spawnInterval = 1f;
+
+            public string EnemyId => enemyId;
+            public int Count => Mathf.Max(0, count);
+            public float SpawnInterval => Mathf.Max(0f, spawnInterval);
+        }
+    }
+}

--- a/unity/Assets/Scripts/Managers/LevelManager.cs
+++ b/unity/Assets/Scripts/Managers/LevelManager.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using UnityEngine;
+using TD.Data;
 
 namespace TD.Managers
 {
@@ -9,64 +10,123 @@ namespace TD.Managers
     /// </summary>
     public class LevelManager : MonoBehaviour
     {
-        public event Action<int> LevelLoaded;
-        public event Action<int> LevelCompleted;
-        public event Action<int> LevelFailed;
+        public event Action<LevelData> LevelLoaded;
+        public event Action<LevelData> LevelStarted;
+        public event Action<LevelData> LevelCompleted;
+        public event Action<LevelData> LevelFailed;
 
-        [SerializeField] private List<LevelDefinition> availableLevels = new();
+        [SerializeField] private List<LevelData> availableLevels = new();
+        [SerializeField] private WaveManager waveManager;
 
         public int CurrentLevelIndex { get; private set; } = -1;
-        public LevelDefinition CurrentLevel { get; private set; }
+        public LevelData CurrentLevel { get; private set; }
+        public bool LevelIsRunning { get; private set; }
 
-        public void Initialize()
-        {
-            // TODO: Load level metadata from resources or persistence.
-        }
+        public IReadOnlyList<LevelData> AvailableLevels => availableLevels;
 
         public void LoadLevel(int levelIndex)
         {
-            // TODO: Load scene/level data and configure environment.
+            if (levelIndex < 0 || levelIndex >= availableLevels.Count)
+            {
+                Debug.LogError($"Level index {levelIndex} is out of bounds.");
+                return;
+            }
+
+            CurrentLevelIndex = levelIndex;
+            CurrentLevel = availableLevels[levelIndex];
+            LevelIsRunning = false;
+
+            if (waveManager != null)
+            {
+                waveManager.ConfigureForLevel(CurrentLevel);
+                waveManager.AllWavesCompleted -= HandleAllWavesCompleted;
+                waveManager.AllWavesCompleted += HandleAllWavesCompleted;
+            }
+
+            LevelLoaded?.Invoke(CurrentLevel);
+        }
+
+        public void LoadLevel(LevelData levelData)
+        {
+            int index = availableLevels.IndexOf(levelData);
+            if (index >= 0)
+            {
+                LoadLevel(index);
+                return;
+            }
+
+            availableLevels.Add(levelData);
+            LoadLevel(availableLevels.Count - 1);
+        }
+
+        public void StartLevel()
+        {
+            if (CurrentLevel == null)
+            {
+                Debug.LogWarning("Cannot start level: no level loaded.");
+                return;
+            }
+
+            if (LevelIsRunning)
+            {
+                Debug.LogWarning("Level is already running.");
+                return;
+            }
+
+            LevelIsRunning = true;
+            LevelStarted?.Invoke(CurrentLevel);
+
+            if (waveManager != null)
+            {
+                waveManager.StartWaves();
+            }
         }
 
         public void RestartLevel()
         {
-            // TODO: Reset current level state and reinitialize systems.
+            if (CurrentLevelIndex >= 0)
+            {
+                LoadLevel(CurrentLevelIndex);
+                StartLevel();
+            }
         }
 
         public void CompleteLevel()
         {
-            // TODO: Handle victory logic and trigger events.
+            if (!LevelIsRunning)
+            {
+                return;
+            }
+
+            LevelIsRunning = false;
+            LevelCompleted?.Invoke(CurrentLevel);
         }
 
         public void FailLevel()
         {
-            // TODO: Handle defeat logic and trigger events.
+            if (!LevelIsRunning)
+            {
+                return;
+            }
+
+            LevelIsRunning = false;
+
+            if (waveManager != null)
+            {
+                waveManager.StopWaves();
+            }
+
+            LevelFailed?.Invoke(CurrentLevel);
         }
-    }
 
-    [Serializable]
-    public class LevelDefinition
-    {
-        [field: SerializeField] public string LevelName { get; private set; }
-        [field: SerializeField] public string SceneName { get; private set; }
-        [field: SerializeField] public int StartingCurrency { get; private set; }
-        [field: SerializeField] public int StartingLives { get; private set; }
-        [field: SerializeField] public List<WaveDefinition> Waves { get; private set; }
-    }
+        private void HandleAllWavesCompleted(LevelData level)
+        {
+            if (level != CurrentLevel || !LevelIsRunning)
+            {
+                return;
+            }
 
-    [Serializable]
-    public class WaveDefinition
-    {
-        [field: SerializeField] public string WaveId { get; private set; }
-        [field: SerializeField] public float DelayBeforeStart { get; private set; }
-        [field: SerializeField] public List<EnemySpawnDefinition> Enemies { get; private set; }
-    }
-
-    [Serializable]
-    public class EnemySpawnDefinition
-    {
-        [field: SerializeField] public string EnemyId { get; private set; }
-        [field: SerializeField] public int Count { get; private set; }
-        [field: SerializeField] public float SpawnInterval { get; private set; }
+            CompleteLevel();
+        }
     }
 }

--- a/unity/Assets/Scripts/Managers/WaveManager.cs
+++ b/unity/Assets/Scripts/Managers/WaveManager.cs
@@ -1,6 +1,9 @@
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
+using TD.Data;
+using TD.Gameplay.Enemies;
 
 namespace TD.Managers
 {
@@ -9,49 +12,235 @@ namespace TD.Managers
     /// </summary>
     public class WaveManager : MonoBehaviour
     {
-        public event Action<int> WaveStarted;
-        public event Action<int> WaveCompleted;
-        public event Action AllWavesCompleted;
+        public event Action<WaveData, int> WaveStarted;
+        public event Action<WaveData, int> WaveCompleted;
+        public event Action<LevelData> AllWavesCompleted;
 
         [SerializeField] private EnemyManager enemyManager;
-        [SerializeField] private LevelManager levelManager;
 
-        private readonly Queue<WaveRuntimeData> pendingWaves = new();
+        private readonly Queue<WaveData> pendingWaves = new();
+        private Coroutine activeRoutine;
+        private LevelData currentLevel;
+        private WaveData currentWave;
+        private int currentWaveIndex = -1;
+        private int activeEnemyCount;
+        private bool wavesConfigured;
+        private bool wavesSpawned;
+        private bool levelCompletionRaised;
+
         public bool IsRunning { get; private set; }
-        public int CurrentWaveIndex { get; private set; } = -1;
+        public int CurrentWaveIndex => currentWaveIndex;
+        public WaveData CurrentWave => currentWave;
 
-        public void Initialize()
+        private void OnEnable()
         {
-            // TODO: Prepare wave queue based on current level definition.
+            if (enemyManager != null)
+            {
+                enemyManager.EnemySpawned += HandleEnemySpawned;
+                enemyManager.EnemyDespawned += HandleEnemyDespawned;
+            }
+        }
+
+        private void OnDisable()
+        {
+            if (enemyManager != null)
+            {
+                enemyManager.EnemySpawned -= HandleEnemySpawned;
+                enemyManager.EnemyDespawned -= HandleEnemyDespawned;
+            }
+        }
+
+        public void ConfigureForLevel(LevelData level)
+        {
+            StopActiveRoutine();
+
+            currentLevel = level;
+            pendingWaves.Clear();
+            currentWave = null;
+            currentWaveIndex = -1;
+            activeEnemyCount = 0;
+            wavesConfigured = level != null;
+            wavesSpawned = false;
+            levelCompletionRaised = false;
+
+            if (level == null)
+            {
+                return;
+            }
+
+            foreach (var wave in level.Waves)
+            {
+                if (wave != null)
+                {
+                    pendingWaves.Enqueue(wave);
+                }
+            }
         }
 
         public void StartWaves()
         {
-            // TODO: Begin processing waves.
+            if (!wavesConfigured)
+            {
+                Debug.LogWarning("WaveManager cannot start: no level configured.");
+                return;
+            }
+
+            if (IsRunning)
+            {
+                Debug.LogWarning("WaveManager is already running.");
+                return;
+            }
+
+            if (pendingWaves.Count == 0)
+            {
+                wavesSpawned = true;
+                TryFinalizeLevel();
+                return;
+            }
+
+            activeRoutine = StartCoroutine(RunWaves());
         }
 
         public void StopWaves()
         {
-            // TODO: Stop wave progression and clear queue.
+            StopActiveRoutine();
+
+            IsRunning = false;
+            currentWave = null;
+            currentWaveIndex = -1;
+            pendingWaves.Clear();
+            activeEnemyCount = 0;
+            wavesSpawned = false;
+            levelCompletionRaised = false;
         }
 
-        public void StartNextWave()
+        private void StopActiveRoutine()
         {
-            // TODO: Dequeue next wave and schedule spawns.
+            if (activeRoutine != null)
+            {
+                StopCoroutine(activeRoutine);
+                activeRoutine = null;
+            }
         }
 
-        public void OnEnemyEliminated(string enemyId)
+        private IEnumerator RunWaves()
         {
-            // TODO: Track remaining enemies and close wave when complete.
-        }
-    }
+            IsRunning = true;
 
-    public class WaveRuntimeData
-    {
-        public LevelDefinition LevelDefinition { get; init; }
-        public WaveDefinition WaveDefinition { get; init; }
-        public int WaveIndex { get; init; }
-        public float TimeRemainingUntilStart { get; set; }
-        public int ActiveEnemies { get; set; }
+            while (pendingWaves.Count > 0)
+            {
+                currentWave = pendingWaves.Dequeue();
+                currentWaveIndex++;
+
+                if (currentWave == null)
+                {
+                    continue;
+                }
+
+                float startDelay = Mathf.Max(0f, currentWave.StartDelay);
+                if (startDelay > 0f)
+                {
+                    yield return new WaitForSeconds(startDelay);
+                }
+
+                WaveStarted?.Invoke(currentWave, currentWaveIndex);
+                yield return StartCoroutine(SpawnWave(currentWave));
+                WaveCompleted?.Invoke(currentWave, currentWaveIndex);
+            }
+
+            IsRunning = false;
+            currentWave = null;
+            wavesSpawned = true;
+            TryFinalizeLevel();
+        }
+
+        private IEnumerator SpawnWave(WaveData wave)
+        {
+            foreach (var group in wave.SpawnGroups)
+            {
+                if (group == null)
+                {
+                    continue;
+                }
+
+                int spawnCount = Mathf.Max(0, group.Count);
+                float interval = Mathf.Max(0f, group.SpawnInterval);
+
+                for (int i = 0; i < spawnCount; i++)
+                {
+                    SpawnEnemy(group.EnemyId);
+
+                    bool isLastSpawn = i >= spawnCount - 1;
+                    if (!isLastSpawn)
+                    {
+                        if (interval > 0f)
+                        {
+                            yield return new WaitForSeconds(interval);
+                        }
+                        else
+                        {
+                            yield return null;
+                        }
+                    }
+                }
+            }
+
+            yield return null;
+        }
+
+        private void SpawnEnemy(string enemyId)
+        {
+            if (enemyManager == null)
+            {
+                Debug.LogWarning($"Cannot spawn enemy '{enemyId}': EnemyManager not assigned.");
+                return;
+            }
+
+            EnemyBehaviour enemy = enemyManager.SpawnEnemy(enemyId, Vector3.zero);
+            if (enemy != null)
+            {
+                activeEnemyCount++;
+            }
+            else
+            {
+                Debug.LogWarning($"EnemyManager failed to spawn enemy '{enemyId}'.");
+            }
+        }
+
+        private void HandleEnemySpawned(EnemyBehaviour enemy)
+        {
+            // Active enemy tracking is handled when SpawnEnemy succeeds, so nothing is required here.
+        }
+
+        private void HandleEnemyDespawned(EnemyBehaviour enemy)
+        {
+            if (activeEnemyCount > 0)
+            {
+                activeEnemyCount--;
+            }
+
+            TryFinalizeLevel();
+        }
+
+        private void TryFinalizeLevel()
+        {
+            if (!wavesSpawned || levelCompletionRaised)
+            {
+                return;
+            }
+
+            if (activeEnemyCount > 0)
+            {
+                return;
+            }
+
+            if (currentLevel == null)
+            {
+                return;
+            }
+
+            levelCompletionRaised = true;
+            AllWavesCompleted?.Invoke(currentLevel);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- add LevelData and WaveData ScriptableObjects for data-driven level and wave definitions
- update LevelManager to orchestrate level lifecycle and hook into wave completion
- implement sequential WaveManager spawning with enemy tracking and completion events

## Testing
- not run (Unity project)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6914715740388329b84f9a0f00ee7416)