### PR TITLE
Refine maze generation and path visuals

### DIFF
--- a/game/td/core/path.py
+++ b/game/td/core/path.py
@@ -1,41 +1,114 @@
+import random
+from collections import deque
+
+
+def _neighbors(cell, cols, rows):
+    x, y = cell
+    if x > 0:
+        yield (x - 1, y)
+    if x < cols - 1:
+        yield (x + 1, y)
+    if y > 0:
+        yield (x, y - 1)
+    if y < rows - 1:
+        yield (x, y + 1)
+
+
+def _generate_maze(cols, rows, rng):
+    adjacency = {(x, y): [] for x in range(cols) for y in range(rows)}
+    start_row = rng.randrange(rows)
+    far_rows = [r for r in range(rows) if abs(r - start_row) >= max(2, rows // 3)]
+    if far_rows:
+        goal_row = rng.choice(far_rows)
+    else:
+        goal_row = (start_row + rows // 2) % rows
+    start = (0, start_row)
+    goal = (cols - 1, goal_row)
+
+    stack = [(start, None)]
+    visited = {start}
+
+    while stack:
+        cell, prev_dir = stack[-1]
+        options = [n for n in _neighbors(cell, cols, rows) if n not in visited]
+        if options:
+            rng.shuffle(options)
+            straight = []
+            if prev_dir:
+                straight = [n for n in options if (n[0] - cell[0], n[1] - cell[1]) == prev_dir]
+            if straight and rng.random() < 0.65:
+                nxt = straight[0]
+            else:
+                nxt = options[0]
+            direction = (nxt[0] - cell[0], nxt[1] - cell[1])
+            adjacency[cell].append(nxt)
+            adjacency[nxt].append(cell)
+            visited.add(nxt)
+            stack.append((nxt, direction))
+        else:
+            stack.pop()
+
+    return adjacency, start, goal
+
+
+def _shortest_path(adjacency, start, goal):
+    queue = deque([start])
+    came_from = {start: None}
+    while queue:
+        cell = queue.popleft()
+        if cell == goal:
+            break
+        for nb in adjacency[cell]:
+            if nb not in came_from:
+                came_from[nb] = cell
+                queue.append(nb)
+
+    if goal not in came_from:
+        return [start]
+
+    path = []
+    cur = goal
+    while cur is not None:
+        path.append(cur)
+        cur = came_from[cur]
+    path.reverse()
+    return path
+
+
 def build_default_path_pixels(tile, viewport):
-    # Build a light S-curve path across the left 75% of the screen.
-    # Returns (path_pixels, path_grid).
+    """Generate a fresh maze-style path for every run.
+
+    Returns a list of pixel waypoints and the grid coordinates that make up the
+    valid path. Enemies will follow the shortest route through the maze,
+    ensuring their path always lines up with the rendered maze corridor.
+    """
+
     left, bottom, w, h = viewport
     usable_w = int(w * 0.75)
-    cols = max(10, usable_w // tile)
-    rows = max(8, int(h // tile))
+    cols = max(12, max(1, usable_w // tile))
+    rows = max(14, max(1, int(h // tile)))
 
-    # Define grid waypoints (col, row)
-    waypoints_grid = [
-        (0, rows//2),
-        (cols//4, rows//2),
-        (cols//4, rows//4),
-        (cols//2, rows//4),
-        (cols//2, 3*rows//4),
-        (3*cols//4, 3*rows//4),
-        (3*cols//4, rows//3),
-        (cols-1, rows//3),
-    ]
+    rng = random.Random()
+    min_length = max(cols + rows // 2, int(cols * 1.1))
+    best_path = None
+    path_cells = None
+    for _ in range(64):
+        adjacency, start, goal = _generate_maze(cols, rows, rng)
+        candidate = _shortest_path(adjacency, start, goal)
+        if len(candidate) != len(set(candidate)):
+            continue
+        if len(candidate) >= min_length:
+            path_cells = candidate
+            break
+        if not best_path or len(candidate) > len(best_path):
+            best_path = candidate
+    if path_cells is None:
+        path_cells = best_path if best_path else candidate
 
     path_pixels = []
-    path_grid = []
-
-    for (gx, gy) in waypoints_grid:
-        x = left + gx * tile + tile/2
-        y = bottom + gy * tile + tile/2
+    for gx, gy in path_cells:
+        x = left + gx * tile + tile / 2
+        y = bottom + gy * tile + tile / 2
         path_pixels.append((x, y))
-        path_grid.append((gx, gy))
 
-    # Interpolate grid cells between waypoints (4-connected)
-    dense_grid = set()
-    for i in range(len(waypoints_grid)-1):
-        x0, y0 = waypoints_grid[i]
-        x1, y1 = waypoints_grid[i+1]
-        steps = max(abs(x1 - x0), abs(y1 - y0))
-        for s in range(steps+1):
-            gx = x0 + (x1 - x0) * s // max(1, steps)
-            gy = y0 + (y1 - y0) * s // max(1, steps)
-            dense_grid.add((int(gx), int(gy)))
-
-    return path_pixels, list(dense_grid)
+    return path_pixels, path_cells

--- a/game/td/screens/game.py
+++ b/game/td/screens/game.py
@@ -5,7 +5,7 @@ from kivy.uix.screenmanager import Screen
 from kivy.uix.widget import Widget
 from kivy.properties import NumericProperty, StringProperty, ObjectProperty
 from kivy.clock import Clock
-from kivy.graphics import Color, Rectangle, Ellipse
+from kivy.graphics import Color, Rectangle, Ellipse, Line
 from kivy.core.image import Image as CoreImage
 from kivy.core.audio import SoundLoader
 from kivy.logger import Logger
@@ -142,18 +142,45 @@ class GameWidget(Widget):
 
             # Path drawn as tiled pixel-art road
             left, bottom, _, _ = self.world.viewport
-            for (gx, gy) in self.world.path_grid:
-                px = left + gx * self.world.tile_size
-                py = bottom + gy * self.world.tile_size
+            tile = self.world.tile_size
+            inner_margin = tile * 0.18
+            edge_band = tile * 0.12
+            path_tiles = list(self.world.path_grid)
+            path_set = set(path_tiles)
+            for (gx, gy) in path_tiles:
+                px = left + gx * tile
+                py = bottom + gy * tile
+
+                Color(0.22, 0.18, 0.14, 1)
+                Rectangle(pos=(px, py), size=(tile, tile))
+
+                inner_pos = (px + inner_margin, py + inner_margin)
+                inner_size = (tile - 2 * inner_margin, tile - 2 * inner_margin)
                 if self.path_tex:
-                    Color(1, 1, 1, 0.9)
-                    Rectangle(texture=self.path_tex, pos=(px, py),
-                              size=(self.world.tile_size, self.world.tile_size))
-                    Color(1, 1, 1, 1)
+                    Color(1, 1, 1, 0.94)
+                    Rectangle(texture=self.path_tex, pos=inner_pos, size=inner_size)
                 else:
-                    Color(0.35, 0.26, 0.18, 1)
-                    Rectangle(pos=(px, py), size=(self.world.tile_size, self.world.tile_size))
-                    Color(1, 1, 1, 1)
+                    Color(0.7, 0.62, 0.54, 1)
+                    Rectangle(pos=inner_pos, size=inner_size)
+
+                Color(0.86, 0.8, 0.69, 0.7)
+                Ellipse(pos=(px + tile * 0.22, py + tile * 0.16), size=(tile * 0.56, tile * 0.6))
+
+                Color(0.14, 0.12, 0.09, 0.9)
+                Line(rectangle=(inner_pos[0], inner_pos[1], inner_size[0], inner_size[1]),
+                     width=max(1.2, tile * 0.05))
+
+                Color(0.16, 0.13, 0.1, 1)
+                if (gx, gy + 1) not in path_set:
+                    Rectangle(pos=(px, py + tile - edge_band), size=(tile, edge_band))
+                if (gx, gy - 1) not in path_set:
+                    Rectangle(pos=(px, py), size=(tile, edge_band))
+                if (gx - 1, gy) not in path_set:
+                    Rectangle(pos=(px, py), size=(edge_band, tile))
+                if (gx + 1, gy) not in path_set:
+                    Rectangle(pos=(px + tile - edge_band, py), size=(edge_band, tile))
+
+                Color(1, 1, 1, 1)
 
             # Towers
             for t in self.world.towers:


### PR DESCRIPTION
## Summary
- tweak the depth-first maze generator to favor longer corridors and retry until a non-intersecting, winding route is found
- reject short paths so the enemy walk cycles traverse a larger maze before converting to pixel waypoints
- redraw the road with layered shading and borders so the maze appears as a stone trail with a distinct edge

## Testing
- python -m compileall game/td

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6914d00e1c0c8329a2fe1aba21a14086)